### PR TITLE
fix: 존재하지 않는 API에 대해 401 대신 404 반환

### DIFF
--- a/src/main/java/com/danjitalk/danjitalk/common/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/danjitalk/danjitalk/common/security/CustomAuthenticationEntryPoint.java
@@ -4,18 +4,36 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @Slf4j
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final RequestMappingHandlerMapping handlerMapping;
 
     @Override // 401 일때 옴
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        log.info("CustomAuthenticationEntryPoint");
+        log.info("CustomAuthenticationEntryPoint#commence");
         log.info("response.getStatus(): {}", response.getStatus());
         log.info("URI: {}", request.getRequestURI());
-        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+        HandlerExecutionChain handler;
+        try {
+            handler = handlerMapping.getHandler(request);
+        } catch (Exception e) {
+            handler = null;
+        }
+
+        // 핸들러가 없는 경우 404 반환
+        if (handler == null) {
+            log.info("Not Found Handler");
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, "Not Found");
+        }
     }
 }

--- a/src/main/java/com/danjitalk/danjitalk/config/SecurityConfig.java
+++ b/src/main/java/com/danjitalk/danjitalk/config/SecurityConfig.java
@@ -26,6 +26,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 @Configuration
 @EnableWebSecurity(debug = true)
@@ -40,6 +41,7 @@ public class SecurityConfig {
     private final AccessTokenUtil accessTokenUtil;
     private final PrincipalOauth2UserService principalOauth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final RequestMappingHandlerMapping handlerMapping;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -54,7 +56,7 @@ public class SecurityConfig {
 
         http
             .exceptionHandling(handler->handler
-                .authenticationEntryPoint(new CustomAuthenticationEntryPoint()) // 401
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint(handlerMapping)) // 401
             ); //AccessDeniedHandler 403
 
         http


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/509452ec-d6a8-4f5b-9b79-b15ad512edc2)


존재하지 않는 API에 대해 요청 시 인증 정보가 없을 때, Security 설정으로 인해 401 오류가 반환되던 문제를 404 오류가 반환되도록 수정하였습니다.