### PR TITLE
소셜 로그인 토큰 발급 로직 추가 

### DIFF
--- a/src/main/java/com/danjitalk/danjitalk/api/oauth/OAuthController.java
+++ b/src/main/java/com/danjitalk/danjitalk/api/oauth/OAuthController.java
@@ -1,17 +1,58 @@
 package com.danjitalk.danjitalk.api.oauth;
 
 import com.danjitalk.danjitalk.common.security.CustomMemberDetails;
+import com.danjitalk.danjitalk.common.util.JwtUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Slf4j
+@RequiredArgsConstructor
 public class OAuthController {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JwtUtil jwtUtil;
 
     @GetMapping("/api/success/oauth")
     public ResponseEntity successOAuth(@AuthenticationPrincipal CustomMemberDetails memberDetails) {
         memberDetails.getEmail();
         return ResponseEntity.ok(memberDetails.getEmail());
+    }
+
+    @GetMapping("/api/oauth/exchange")
+    public ResponseEntity oauthExchange(HttpServletResponse response, @RequestParam String code) {
+        log.info("oauthExchange: {}", code);
+
+        Map<String, Object> data = (Map<String, Object>) redisTemplate.opsForValue().get(code);
+
+        Map<String, Object> accessClaims = new HashMap<>();
+        accessClaims.put("memberId", data.get("memberId"));
+        accessClaims.put("memberEmail", data.get("memberEmail"));
+        accessClaims.put("provider", data.get("provider"));
+
+        Map<String, Object> refreshClaims = new HashMap<>();
+        refreshClaims.put("memberEmail", data.get("memberEmail"));
+
+        String accessToken = jwtUtil.createAccessToken(accessClaims);
+        String refreshToken = jwtUtil.createRefreshToken(refreshClaims);
+
+        ResponseCookie accessTokenCookie = jwtUtil.generateAccessTokenCookie(accessToken); // localhost로 하면 아예 쿠키 저장안됌
+        ResponseCookie refreshTokenCookie = jwtUtil.generateRefreshTokenCookie(refreshToken);
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/danjitalk/danjitalk/api/oauth/OAuthController.java
+++ b/src/main/java/com/danjitalk/danjitalk/api/oauth/OAuthController.java
@@ -31,10 +31,11 @@ public class OAuthController {
     }
 
     @GetMapping("/api/oauth/exchange")
-    public ResponseEntity oauthExchange(HttpServletResponse response, @RequestParam String code) {
+    public ResponseEntity<Void> oauthExchange(HttpServletResponse response, @RequestParam String code) {
         log.info("oauthExchange: {}", code);
 
-        Map<String, Object> data = (Map<String, Object>) redisTemplate.opsForValue().get(code);
+        String key = "jwt:temp:claim:" + code;
+        Map<String, Object> data = (Map<String, Object>) redisTemplate.opsForValue().get(key);
 
         Map<String, Object> accessClaims = new HashMap<>();
         accessClaims.put("memberId", data.get("memberId"));

--- a/src/main/java/com/danjitalk/danjitalk/application/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/danjitalk/danjitalk/application/oauth/OAuth2LoginSuccessHandler.java
@@ -53,7 +53,9 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         map.put("memberEmail", user.getLoginId());
         map.put("provider", user.getLastLoginMethod());
 
-        redisTemplate.opsForValue().set(uuid, map, Duration.ofMinutes(3));
+        String key = "jwt:temp:claim:" + uuid;
+
+        redisTemplate.opsForValue().set(key, map, Duration.ofMinutes(3));
 
         // 성공 후 리다이렉트 SecurityConfig에 .defaultSuccessUrl("/api/success/oauth")는 쿠키설정이 안됨
         getRedirectStrategy().sendRedirect(request, response, frontendRedirectUrl + "/oauth/redirect?status=success&social-code=" + uuid); // 리다이렉트 주소

--- a/src/main/java/com/danjitalk/danjitalk/application/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/danjitalk/danjitalk/application/oauth/OAuth2LoginSuccessHandler.java
@@ -1,48 +1,61 @@
 package com.danjitalk.danjitalk.application.oauth;
 
 import com.danjitalk.danjitalk.common.security.CustomMemberDetails;
-import com.danjitalk.danjitalk.common.util.JwtUtil;
 import com.danjitalk.danjitalk.domain.user.member.entity.SystemUser;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) throws IOException, ServletException {
+
+        String origin = Optional.ofNullable(request.getHeader("Origin"))
+                .orElse(request.getHeader("Referer"));
+
+        String frontendRedirectUrl;
+        if (origin != null && origin.contains("localhost")) {
+            frontendRedirectUrl = "http://localhost:5173";
+        } else {
+            frontendRedirectUrl = "https://danji-talk-frontend.vercel.app";
+        }
+
+        log.info("origin header: {}", origin);
+        log.info("frontendRedirectUrl: {}", frontendRedirectUrl);
+
         // OAuth2 로그인이 성공했을 때의 추가 작업을 수행
         // 여기에서는 JWT 토큰을 발급하고 형식에 맞게 return
         CustomMemberDetails customMemberDetails = (CustomMemberDetails) authentication.getPrincipal();
+        SystemUser user = customMemberDetails.getUser();
+        String uuid = UUID.randomUUID().toString();
 
-        issueAccessTokenCookie(customMemberDetails.getUser(), response);
-        issueRefreshTokenCookie(customMemberDetails.getUser(), response);
+        Map<String, Object> map = new HashMap<>();
+        map.put("memberId", user.getSystemUserId());
+        map.put("memberEmail", user.getLoginId());
+        map.put("provider", user.getLastLoginMethod());
+
+        redisTemplate.opsForValue().set(uuid, map, Duration.ofMinutes(3));
 
         // 성공 후 리다이렉트 SecurityConfig에 .defaultSuccessUrl("/api/success/oauth")는 쿠키설정이 안됨
-        getRedirectStrategy().sendRedirect(request, response, "/api/success/oauth");
-    }
-
-    private void issueAccessTokenCookie(SystemUser systemUser, HttpServletResponse response) {
-        String accessToken = jwtUtil.createAccessToken(systemUser);
-        ResponseCookie accessTokenCookie = jwtUtil.generateAccessTokenCookie(accessToken);
-        response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
-    }
-
-    private void issueRefreshTokenCookie(SystemUser systemUser, HttpServletResponse response) {
-        String refreshToken = jwtUtil.createRefreshToken(systemUser);
-        ResponseCookie refreshTokenCookie = jwtUtil.generateRefreshTokenCookie(refreshToken);
-        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+        getRedirectStrategy().sendRedirect(request, response, frontendRedirectUrl + "/oauth/redirect?status=success&social-code=" + uuid); // 리다이렉트 주소
     }
 }

--- a/src/main/java/com/danjitalk/danjitalk/common/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/danjitalk/danjitalk/common/security/JwtAuthorizationFilter.java
@@ -77,6 +77,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
             // 리프레시는 있다면 유효성 검사 하고
             if (!refreshTokenUtil.checkIfRefreshTokenValid(refreshToken)) {
+                log.info("refresh token: {}", refreshToken);
                 ResponseUtil.createResponseBody(response, HttpStatus.UNAUTHORIZED, "access-token expired, refresh-token is invalid");
                 filterChain.doFilter(request, response);
                 return;
@@ -101,6 +102,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         SystemUser systemUser = null;
 
         try {
+            log.info("accessToken: {}", accessToken);
             claims = accessTokenUtil.getClaimsFromAccessToken(accessToken);
         } catch (ExpiredJwtException e) {
             // 엑세스 토큰이 만료되었을 때 리프레시 토큰이 유효하다면, 엑세스 토큰을 새로 발급해줍니다.

--- a/src/main/java/com/danjitalk/danjitalk/common/util/JwtUtil.java
+++ b/src/main/java/com/danjitalk/danjitalk/common/util/JwtUtil.java
@@ -39,10 +39,28 @@ public class JwtUtil {
             .compact();
     }
 
+    public String createAccessToken(Map<String, Object> claims) {
+        return Jwts.builder()
+            .subject("accessToken")
+            .claims(claims)
+            .expiration(createTokenExpiration(ACCESS_TOKEN_VALIDITY_TIME))
+            .signWith(createSigningKey(jwtSecretKeys.getAccessSecret()))
+            .compact();
+    }
+
     public String createRefreshToken(SystemUser user) {
         return Jwts.builder()
             .subject("refreshToken")
             .claims(createRefreshTokenClaims(user))
+            .expiration(createTokenExpiration(REFRESH_TOKEN_VALIDITY_TIME))
+            .signWith(createSigningKey(jwtSecretKeys.getRefreshSecret()))
+            .compact();
+    }
+
+    public String createRefreshToken(Map<String, Object> claims) {
+        return Jwts.builder()
+            .subject("refreshToken")
+            .claims(claims)
             .expiration(createTokenExpiration(REFRESH_TOKEN_VALIDITY_TIME))
             .signWith(createSigningKey(jwtSecretKeys.getRefreshSecret()))
             .compact();

--- a/src/main/java/com/danjitalk/danjitalk/config/RedisConfig.java
+++ b/src/main/java/com/danjitalk/danjitalk/config/RedisConfig.java
@@ -30,9 +30,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate() {
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setConnectionFactory(factory);
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;

--- a/src/main/java/com/danjitalk/danjitalk/config/RedisConfig.java
+++ b/src/main/java/com/danjitalk/danjitalk/config/RedisConfig.java
@@ -3,11 +3,11 @@ package com.danjitalk.danjitalk.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -34,7 +34,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         return redisTemplate;
     }
 }

--- a/src/main/java/com/danjitalk/danjitalk/config/SecurityConfig.java
+++ b/src/main/java/com/danjitalk/danjitalk/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
                 .userService(principalOauth2UserService)
             )
             .successHandler(oAuth2LoginSuccessHandler)
+//                .failureHandler() // TODO
         );
 
         return http.build();
@@ -114,6 +115,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() { // 시큐리티와 관련 없는(인증/인가 필요 없는) 필터를 타면 안되는 경로
         return web -> {
             web.ignoring()
+                .requestMatchers("/api/oauth/exchange")
                 .requestMatchers(HttpMethod.POST, "/api/member/signup")
                 .requestMatchers(HttpMethod.POST, "/api/member/check-email-duplication")
                 .requestMatchers(HttpMethod.POST, "/api/mail/certification-code/send")


### PR DESCRIPTION
- 소셜 로그인 성공 시 UUID를 리다이렉트 URL에 포함
- UUID를 통해 백엔드에서 액세스/리프레시 토큰으로 교환 가능