### PR TITLE
웹소켓 연결 방식 수정

### DIFF
--- a/src/main/java/com/danjitalk/danjitalk/application/chat/CustomHandshakeInterceptor.java
+++ b/src/main/java/com/danjitalk/danjitalk/application/chat/CustomHandshakeInterceptor.java
@@ -1,41 +1,64 @@
 package com.danjitalk.danjitalk.application.chat;
 
-import com.danjitalk.danjitalk.common.security.CustomMemberDetails;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.server.HandshakeInterceptor;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
         Map<String, Object> attributes) throws Exception {
         log.info("before handshake");
 
-        // 인증 실패 시 false 반환 핸드셰이크 실패처리
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String query = request.getURI().getQuery();
 
-        log.info("authentication: {}", authentication);
-        // 인증이 없거나 인증되지 않은 경우
-        if (authentication == null || !authentication.isAuthenticated()) {
-            log.warn("authentication is not authenticated");
+        if (query == null || !query.startsWith("token=")) {
             return false;
         }
 
-        // principal이 CustomMemberDetails 타입이 아닌 경우
-        Object principal = authentication.getPrincipal();
-        if (!(principal instanceof CustomMemberDetails)) {
-            log.warn("principal is not valid");
-            return false;
-        }
+        String token = query.substring("token=".length());
+        log.info("token: {}", token);
+
+        String key = "ws:temp:claim:" + token;
+        Map<String, Object> data = (Map<String, Object>) redisTemplate.opsForValue().get(key);
+
+        attributes.put("memberId", data.get("memberId"));
+        attributes.put("email", data.get("memberEmail"));
+        attributes.put("userId", data.get("userId"));
+
+        log.info("attributes {}", attributes);
+
+
+//        ContextHolder 사용 시 로직 ws연결 시 쿠키를 얻어오지 못해(시큐리티 필터에서 Anonymous처리 되어) 주석처리
+
+//        // 인증 실패 시 false 반환 핸드셰이크 실패처리
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//
+//        log.info("authentication: {}", authentication);
+//        // 인증이 없거나 인증되지 않은 경우
+//        if (authentication == null || !authentication.isAuthenticated()) {
+//            log.warn("authentication is not authenticated");
+//            return false;
+//        }
+//
+//        // principal이 CustomMemberDetails 타입이 아닌 경우
+//        Object principal = authentication.getPrincipal();
+//        if (!(principal instanceof CustomMemberDetails)) {
+//            log.warn("principal is not valid");
+//            return false;
+//        }
 
         return true;
     }

--- a/src/main/java/com/danjitalk/danjitalk/config/WebConfig.java
+++ b/src/main/java/com/danjitalk/danjitalk/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5174", "http://localhost:5173", "https://danji-talk-frontend.vercel.app")
+                .allowedOrigins("http://localhost:5174", "http://localhost:5173", "https://danji-talk-frontend.vercel.app", "https://danji-talk-frontend-rosy.vercel.app")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .maxAge(3600)

--- a/src/main/java/com/danjitalk/danjitalk/event/handler/StompEventHandler.java
+++ b/src/main/java/com/danjitalk/danjitalk/event/handler/StompEventHandler.java
@@ -46,18 +46,18 @@ public class StompEventHandler { //StompSubProtocolHandler 에서 이벤트 처�
     @EventListener
     public void handleConnectEventListener(SessionConnectEvent event) { // StompCommand.CONNECT or StompCommand.STOMP 일 때 실행
         log.info("사용자 연결 전 소켓 연결, 헤더에 기본값 세팅");
-
-        MessageHeaders headers = event.getMessage().getHeaders();
-        log.info("headers {}", headers);
-
-        Map<String, Object> sessionAttributes = (Map<String, Object>) headers.get("simpSessionAttributes");
-        UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) headers.get("simpUser");
-        String email = token.getName();
-        CustomMemberDetails customMemberDetails = (CustomMemberDetails) token.getPrincipal();
-        sessionAttributes.put("email", email);
-        sessionAttributes.put("memberId", customMemberDetails.getUser().getMember().getId());
-
-        log.info("After setting the headers: {}", headers);
+//        기본값 세팅은 핸드셰이크에서 하는게 맞으나 참고용으로 남김
+//        MessageHeaders headers = event.getMessage().getHeaders();
+//        log.info("headers {}", headers);
+//
+//        Map<String, Object> sessionAttributes = (Map<String, Object>) headers.get("simpSessionAttributes");
+//        UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken) headers.get("simpUser");
+//        String email = token.getName();
+//        CustomMemberDetails customMemberDetails = (CustomMemberDetails) token.getPrincipal();
+//        sessionAttributes.put("email", email);
+//        sessionAttributes.put("memberId", customMemberDetails.getUser().getMember().getId());
+//
+//        log.info("After setting the headers: {}", headers);
     }
 
     @EventListener


### PR DESCRIPTION
시큐리티 기반 인증 방식에서, 도메인이 서로 달라 쿠키가 전송되지 않아 SecurityContextHolder에서 인증 정보를 가져올 수 없었고, 이로 인해 WebSocket 인증이 실패했습니다.
이를 해결하기 위해, 서버에서 임시 토큰을 발급한 후 클라이언트가 해당 토큰을 사용해 WebSocket 연결 시 인증을 수행하도록 인증 방식을 수정했습니다.

