### PR TITLE
리액션 여부 판단을 현재 사용자 기준으로 수정 

### DIFF
--- a/src/main/java/com/danjitalk/danjitalk/application/community/feed/FeedService.java
+++ b/src/main/java/com/danjitalk/danjitalk/application/community/feed/FeedService.java
@@ -100,13 +100,16 @@ public class FeedService {
         }
 
         Feed feed = feedRepository.findFeedFetchJoinMemberByFeedId((feedId)).orElseThrow(DataNotFoundException::new);
-        Boolean reacted = this.isReacted(feed.getId(), feed.getMember().getId());
+
+        Optional<Long> currentMemberId = SecurityContextHolderUtil.getMemberIdOptional();
+
+        Boolean reacted = currentMemberId.map(memberId -> isReacted(feed.getId(), memberId)).orElse(false); // 자기글에 자기가 좋아요 눌렀는지만 확인하고 있었음
 
         List<S3ObjectResponseDto> s3ObjectResponseDtoList = Optional.ofNullable(feed.getFileUrl()).map(url -> s3Service.getS3Object(url)).orElseGet(Collections::emptyList);
 
         Boolean bookmarked = bookmarkService.isBookmarked(feedId, BookmarkType.FEED);
 
-        Boolean isAuthor = SecurityContextHolderUtil.getMemberId().equals(feed.getMember().getId());
+        Boolean isAuthor = currentMemberId.map(memberId -> memberId.equals(feed.getMember().getId())).orElse(false);
 
         return new FeedDetailResponseDto(
                 feed.getId(),


### PR DESCRIPTION
- 리액션 여부를 판단하는 로직이 현재 사용자가 아니라 게시글 작성자 기준으로 동작하고 있는 문제 수정
- 로그인 하지 않은 사용자가 조회를 하면 예외가 터지는 문제 수정